### PR TITLE
Add condition to check ignore_op3 for missing atoms

### DIFF
--- a/rna_tools/rna_tools_lib.py
+++ b/rna_tools/rna_tools_lib.py
@@ -1659,7 +1659,7 @@ class RNAStructure:
                             p_missing = False
                     logger.debug('p_missing %s' % p_missing)
 
-                    if p_missing and fix_missing_atoms:
+                    if p_missing and fix_missing_atoms and (not ignore_op3):
                         currfn = __file__
                         if currfn == '':
                             path = '.'


### PR DESCRIPTION
Honor ignore_op3 at chain start: rebuild 5′ P/OP1/OP2 only when missing and ignore_op3 is False.